### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sync-branch.yml
+++ b/.github/workflows/sync-branch.yml
@@ -4,6 +4,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   sync-branches:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/mnsrulz/mytradingview/security/code-scanning/1](https://github.com/mnsrulz/mytradingview/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the least privileges required. Based on the workflow's functionality:
- The `contents: read` permission is needed to check out the repository.
- The `pull-requests: write` permission is required to open a pull request using the `tretuna/sync-branches@1.4.0` action.

The `permissions` block will be added at the root level of the workflow to apply to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
